### PR TITLE
Clean up the qt6 code, and add the pdbaltpath link arg for msvc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -104,7 +104,14 @@ if maya_link_qt
     qt_moc_path = maya_bin_dir / 'moc'
     if maya_devkit_base != ''
       qt_lib_dir = maya_devkit_base / 'Qt' / 'lib'
-      qt_moc_path = maya_devkit_base / 'Qt' / 'libexec' / 'moc'
+
+      mocdirs = [
+        maya_devkit_base / 'Qt' / 'bin',
+        maya_devkit_base / 'Qt' / 'libexec',
+      ]
+      moc_prg = find_program('moc', dirs : mocdirs, required : true)
+      qt_moc_path = moc_prg.full_path()
+
       includes += include_directories(maya_devkit_base / 'Qt' / 'include')
     endif
   else

--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,13 @@ if os_name == 'windows'
   maya_install_base = 'c:/Program Files/Autodesk'
   maya_plugin_ext = 'mll'
   maya_compile_args += ['-DNT_PLUGIN', '/Zc:__cplusplus']
-  maya_link_args = ['/export:initializePlugin', '/export:uninitializePlugin']
+  maya_link_args = [
+    # Export the methods that maya requires
+    '/export:initializePlugin',
+    '/export:uninitializePlugin',
+    # Make sure to look for pdb file in the same directory as the .mll
+    '/PDBALTPATH:%_PDB%',
+  ]
 elif os_name == 'darwin'
   maya_install_base = '/Applications/Autodesk'
   maya_plugin_ext = 'bundle'
@@ -79,35 +85,52 @@ maya_libs = [
 # Link to maya's qt libs if required
 # Below, I expose the bin and include dirs so I can directly invoke the
 # moc exe included with maya. Saves from having to make a maya qt module
+
+qt_moc_path = ''
 if maya_link_qt
   fs = import('fs')
-  if not fs.is_dir(maya_inc_dir / 'QtCore')
-    error(
-      'Could not find Maya QT headers with `maya_link_qt` defined\n',
-      'You probably need to unzip `include/qt_*-include.zip`\n',
-      'Checking in folder: ', maya_inc_dir,
-    )
-  endif
-  qt_ver = 5
-  if maya_version.version_compare('>=2025')
-    qt_ver = 6
-  endif
-  maya_qt_lib_names = [f'Qt@qt_ver@Core', f'Qt@qt_ver@Gui', f'Qt@qt_ver@Widgets']
 
-  qt_lib_dir = maya_lib_dir
-  if maya_devkit_base != ''
-    qt_lib_dir = maya_devkit_base / 'Qt' / 'lib'
-    qt_inc_dir = maya_devkit_base / 'Qt' / 'include'
-    includes += include_directories(qt_inc_dir)
+  if maya_version.version_compare('>=2025')
+    if not fs.is_dir(maya_install_path / 'Qt' / 'include' / 'QtCore')
+      error(
+        'Could not find Maya QT headers with `maya_link_qt` defined\n',
+        'You probably need to unzip `devkitBase/Qt.zip`\n',
+        'Checking in folder: ', maya_install_path,
+      )
+    endif
+    maya_qt_lib_names = [f'Qt6Core', f'Qt6Gui', f'Qt6Widgets']
+
+    qt_lib_dir = maya_lib_dir
+    qt_moc_path = maya_bin_dir / 'moc'
+    if maya_devkit_base != ''
+      qt_lib_dir = maya_devkit_base / 'Qt' / 'lib'
+      qt_moc_path = maya_devkit_base / 'Qt' / 'libexec' / 'moc'
+      includes += include_directories(maya_devkit_base / 'Qt' / 'include')
+    endif
+  else
+    if not fs.is_dir(maya_inc_dir / 'QtCore')
+      error(
+        'Could not find Maya QT headers with `maya_link_qt` defined\n',
+        'You probably need to unzip `include/qt_*-include.zip`\n',
+        'Checking in folder: ', maya_inc_dir,
+      )
+    endif
+    qt_ver = 5
+    maya_qt_lib_names = [f'Qt5Core', f'Qt5Gui', f'Qt5Widgets']
+    qt_lib_dir = maya_lib_dir
+    qt_moc_path = maya_bin_dir / 'moc'
+    if maya_devkit_base != ''
+      qt_moc_path = maya_devkit_base / 'devkit' / 'bin' / 'moc'
+    endif
   endif
 
   if maya_qt_extra_includes != ''
     maya_qt_lib_names += maya_qt_extra_includes.split(';')
   endif
-
   foreach lib_name : maya_qt_lib_names
       maya_libs += cmplr.find_library(lib_name, dirs : qt_lib_dir)
   endforeach
+
 endif
 
 maya_dep = declare_dependency(
@@ -118,6 +141,7 @@ maya_dep = declare_dependency(
     'maya_version' : maya_version,
     'maya_bin_dir': maya_bin_dir,
     'maya_inc_dir': maya_inc_dir,
+    'qt_moc_path': qt_moc_path,
   },
   compile_args : maya_compile_args,
   link_args : maya_link_args,


### PR DESCRIPTION
I like to copy the .mll and .pdb to a separate folder outside of the build directory before I load the plugin into maya. This allows me to compile a new version of the plugin while maya still has the older version loaded.
Unfortunately, msvc puts an absolute path to the .pdb file into the .mll, and then Maya will sometimes load the .pdb file, thus locking me out of compiling. And maya won't release the .pdb when I unload the .mll, so I've gotta kill maya to be able to recompile.
So I'm adding the `pdbaltpath` argument for msvc. This makes the debugger look for the .pdb file that sits right next to it instead of at some hard-coded path.

This is on top of https://github.com/blurstudio/mayaMesonSubproject/pull/2, so those changes are in here too. 

When I have a chance to make sure this works across all our libraries (and when I remember), I'll merge this